### PR TITLE
Upgrade rancher module and nginx ingress module to Helm provider version 3

### DIFF
--- a/k8s/ingress-controller-nginx/kind_test.tftest.hcl
+++ b/k8s/ingress-controller-nginx/kind_test.tftest.hcl
@@ -4,7 +4,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     config_path    = "~/.kube/config"
     config_context = "kind-kind"
   }

--- a/k8s/ingress-controller-nginx/main.tf
+++ b/k8s/ingress-controller-nginx/main.tf
@@ -7,7 +7,8 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     helm = {
-      source = "hashicorp/helm"
+      source  = "hashicorp/helm"
+      version = ">= 3"
     }
   }
 }

--- a/k8s/ingress-controller-nginx/nginx-ingress.tf
+++ b/k8s/ingress-controller-nginx/nginx-ingress.tf
@@ -63,13 +63,7 @@ resource "helm_release" "ingress_nginx" {
     var.extra_values != null ? yamlencode(var.extra_values) : null,
   ])
 
-  dynamic "set" {
-    for_each = var.additional_set_values
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
+  set = [for k, v in var.additional_set_values : { name = k, value = tostring(v) }]
 
   # Ensure the custom error pages are created before the ingress controller is deployed
   depends_on = [kubernetes_config_map_v1.ingress_custom_error_pages]

--- a/k8s/ingress-controller-nginx/outputs.tf
+++ b/k8s/ingress-controller-nginx/outputs.tf
@@ -25,7 +25,7 @@ output "ingress_class_name" {
 
 output "chart_version" {
   description = "Installed chart version of the ingress controller"
-  value       = one(helm_release.ingress_nginx.metadata).version
+  value       = helm_release.ingress_nginx.metadata.version
 }
 
 output "values" {

--- a/k8s/rancher/bootstrap/configuration.tftest.hcl
+++ b/k8s/rancher/bootstrap/configuration.tftest.hcl
@@ -7,9 +7,13 @@ mock_provider "rancher2" {
   }
 }
 
+variables {
+  bootstrap_password = "initialPassword1234"
+}
+
 run "default" {
   assert {
-    condition     = (output.admin_password != null && output.bootstrap_password != null)
+    condition     = output.admin_password != null
     error_message = "Didn't generate credentials"
   }
 }
@@ -27,12 +31,11 @@ run "token_generation" {
 
 run "with_given_passwords" {
   variables {
-    admin_password     = "superSecret1234"
-    bootstrap_password = "superBootstrap1234"
+    admin_password = "superSecret1234"
   }
 
   assert {
-    condition     = output.admin_password == var.admin_password && output.bootstrap_password == var.bootstrap_password
+    condition     = output.admin_password == var.admin_password
     error_message = "Didn't generate credentials"
   }
 }

--- a/k8s/rancher/bootstrap/configuration.tftest.hcl
+++ b/k8s/rancher/bootstrap/configuration.tftest.hcl
@@ -1,0 +1,38 @@
+mock_provider "rancher2" {
+  mock_resource "rancher2_bootstrap" {
+    defaults = {
+      token    = "access_key:secret_key"
+      token_id = "access_key"
+    }
+  }
+}
+
+run "default" {
+  assert {
+    condition     = (output.admin_password != null && output.bootstrap_password != null)
+    error_message = "Didn't generate credentials"
+  }
+}
+
+run "token_generation" {
+  assert {
+    condition = alltrue([
+      output.rancher_token.api_token == "access_key:secret_key",
+      output.rancher_token.access_key == "access_key",
+      output.rancher_token.secret_key == "secret_key"
+    ])
+    error_message = "Didn't generate token"
+  }
+}
+
+run "with_given_passwords" {
+  variables {
+    admin_password     = "superSecret1234"
+    bootstrap_password = "superBootstrap1234"
+  }
+
+  assert {
+    condition     = output.admin_password == var.admin_password && output.bootstrap_password == var.bootstrap_password
+    error_message = "Didn't generate credentials"
+  }
+}

--- a/k8s/rancher/bootstrap/outputs.tf
+++ b/k8s/rancher/bootstrap/outputs.tf
@@ -1,0 +1,21 @@
+output "bootstrap_password" {
+  description = "The bootstrap password"
+  value       = local.bootstrap_password
+  sensitive   = true
+}
+
+output "admin_password" {
+  description = "The current password for the admin user"
+  value       = local.admin_password
+  sensitive   = true
+}
+
+output "rancher_token" {
+  description = "The tokens to access the rancher API"
+  value = {
+    api_token  = rancher2_bootstrap.admin.token,
+    access_key = rancher2_bootstrap.admin.token_id
+    secret_key = split(":", rancher2_bootstrap.admin.token)[1]
+  }
+  sensitive = true
+}

--- a/k8s/rancher/bootstrap/outputs.tf
+++ b/k8s/rancher/bootstrap/outputs.tf
@@ -1,9 +1,3 @@
-output "bootstrap_password" {
-  description = "The bootstrap password"
-  value       = local.bootstrap_password
-  sensitive   = true
-}
-
 output "admin_password" {
   description = "The current password for the admin user"
   value       = local.admin_password

--- a/k8s/rancher/bootstrap/rancher-bootstrap.tf
+++ b/k8s/rancher/bootstrap/rancher-bootstrap.tf
@@ -1,0 +1,34 @@
+terraform {
+  required_providers {
+    rancher2 = {
+      source  = "rancher/rancher2"
+      version = ">= 8"
+    }
+  }
+}
+# bootstrap and admin password
+resource "random_password" "bootstrap" {
+  count  = var.bootstrap_password == null ? 1 : 0
+  length = 16
+}
+
+resource "random_password" "admin" {
+  count  = var.admin_password == null ? 1 : 0
+  length = 16
+}
+
+locals {
+  bootstrap_password = var.bootstrap_password != null ? var.bootstrap_password : random_password.bootstrap[0].result
+  admin_password     = var.admin_password != null ? var.admin_password : random_password.admin[0].result
+}
+
+
+# Bootstrap the rancher installation
+resource "rancher2_bootstrap" "admin" {
+  # Used to bootstrap the rancher installation
+  initial_password = local.bootstrap_password
+  # Will be kept in sync for the admin user
+  password = local.admin_password
+  # By default generate a token that doesn't expire
+  token_ttl = 0
+}

--- a/k8s/rancher/bootstrap/rancher-bootstrap.tf
+++ b/k8s/rancher/bootstrap/rancher-bootstrap.tf
@@ -6,11 +6,6 @@ terraform {
     }
   }
 }
-# bootstrap and admin password
-resource "random_password" "bootstrap" {
-  count  = var.bootstrap_password == null ? 1 : 0
-  length = 16
-}
 
 resource "random_password" "admin" {
   count  = var.admin_password == null ? 1 : 0
@@ -18,15 +13,14 @@ resource "random_password" "admin" {
 }
 
 locals {
-  bootstrap_password = var.bootstrap_password != null ? var.bootstrap_password : random_password.bootstrap[0].result
-  admin_password     = var.admin_password != null ? var.admin_password : random_password.admin[0].result
+  admin_password = var.admin_password != null ? var.admin_password : random_password.admin[0].result
 }
 
 
 # Bootstrap the rancher installation
 resource "rancher2_bootstrap" "admin" {
   # Used to bootstrap the rancher installation
-  initial_password = local.bootstrap_password
+  initial_password = var.bootstrap_password
   # Will be kept in sync for the admin user
   password = local.admin_password
   # By default generate a token that doesn't expire

--- a/k8s/rancher/bootstrap/variables.tf
+++ b/k8s/rancher/bootstrap/variables.tf
@@ -1,8 +1,7 @@
 variable "bootstrap_password" {
   description = "The password to use for bootstrapping rancher, pass this only to import existing installations"
   type        = string
-  default     = null
-  nullable    = true
+  sensitive   = true
 }
 
 variable "admin_password" {
@@ -10,4 +9,5 @@ variable "admin_password" {
   type        = string
   default     = null
   nullable    = true
+  sensitive   = true
 }

--- a/k8s/rancher/bootstrap/variables.tf
+++ b/k8s/rancher/bootstrap/variables.tf
@@ -1,0 +1,13 @@
+variable "bootstrap_password" {
+  description = "The password to use for bootstrapping rancher, pass this only to import existing installations"
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "admin_password" {
+  description = "The password to use for the admin user"
+  type        = string
+  default     = null
+  nullable    = true
+}

--- a/k8s/rancher/configuration.tftest.hcl
+++ b/k8s/rancher/configuration.tftest.hcl
@@ -4,7 +4,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     config_path    = "~/.kube/config"
     config_context = "kind-kind"
   }

--- a/k8s/rancher/kind_rancher.tftest.hcl
+++ b/k8s/rancher/kind_rancher.tftest.hcl
@@ -106,3 +106,15 @@ run "test_login" {
     error_message = "It returns a valid token"
   }
 }
+
+# Patch the cattle-system namespace to remove the finalizer otherwise
+# it won't be able to teardown
+run "remove_finalizer" {
+  module {
+    source = "../../misc/finalizer"
+  }
+
+  variables {
+    name = run.install_full_release.outputs.namespace
+  }
+}

--- a/k8s/rancher/kind_rancher.tftest.hcl
+++ b/k8s/rancher/kind_rancher.tftest.hcl
@@ -10,6 +10,16 @@ provider "helm" {
   }
 }
 
+# Used to bootstrap the Rancher installation
+provider "rancher2" {
+  api_url   = run.install_full_release.server_url
+  bootstrap = true
+  # On creation it might take a while to be ready
+  timeout = "5m"
+  # Usually true only in tests
+  insecure = true
+}
+
 variables {
   hostname    = "rancher.fabn.dev"
   replicas    = 1
@@ -21,11 +31,6 @@ variables {
 run "install_helm_release" {
   command = plan
 
-  variables {
-    bootstrap_password = "superBootstrap1234"
-    admin_password     = "superSecret1234"
-  }
-
   assert {
     condition     = output.release_name == "rancher"
     error_message = "Wrong release name"
@@ -34,14 +39,6 @@ run "install_helm_release" {
   assert {
     condition     = output.server_url == "https://rancher.fabn.dev"
     error_message = "It outputs server url for ${var.hostname}"
-  }
-
-  assert {
-    condition = alltrue([
-      output.bootstrap_password == var.bootstrap_password,
-      output.admin_password == var.admin_password,
-    ])
-    error_message = "It manages passwords"
   }
 }
 
@@ -74,6 +71,25 @@ run "install_full_release" {
   }
 }
 
+run "boostrap" {
+  module {
+    source = "./bootstrap"
+  }
+
+  variables {
+    bootstrap_password = "superBootstrap1234"
+    admin_password     = "superSecret1234"
+  }
+
+  assert {
+    condition = alltrue([
+      output.bootstrap_password == var.bootstrap_password,
+      output.admin_password == var.admin_password,
+    ])
+    error_message = "It manages passwords"
+  }
+}
+
 run "test_login" {
   variables {
     url             = "${run.install_full_release.server_url}/v3-public/localProviders/local?action=login"
@@ -85,7 +101,7 @@ run "test_login" {
     }
     request_body = jsonencode({
       username = "admin",
-      password = run.install_full_release.admin_password
+      password = run.bootstrap.admin_password
     })
   }
 

--- a/k8s/rancher/kind_rancher.tftest.hcl
+++ b/k8s/rancher/kind_rancher.tftest.hcl
@@ -82,7 +82,7 @@ run "install_full_release" {
   }
 }
 
-run "boostrap" {
+run "bootstrap" {
   module {
     source = "./bootstrap"
   }

--- a/k8s/rancher/kind_rancher.tftest.hcl
+++ b/k8s/rancher/kind_rancher.tftest.hcl
@@ -115,6 +115,6 @@ run "remove_finalizer" {
   }
 
   variables {
-    name = run.install_full_release.outputs.namespace
+    name = run.install_full_release.namespace
   }
 }

--- a/k8s/rancher/kind_rancher.tftest.hcl
+++ b/k8s/rancher/kind_rancher.tftest.hcl
@@ -94,8 +94,7 @@ run "boostrap" {
 
   assert {
     condition = alltrue([
-      output.bootstrap_password == var.bootstrap_password,
-      output.admin_password == var.admin_password,
+      output.admin_password == var.admin_password
     ])
     error_message = "It manages passwords"
   }

--- a/k8s/rancher/kind_rancher.tftest.hcl
+++ b/k8s/rancher/kind_rancher.tftest.hcl
@@ -4,7 +4,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     config_path    = "~/.kube/config"
     config_context = "kind-kind"
   }

--- a/k8s/rancher/kind_rancher.tftest.hcl
+++ b/k8s/rancher/kind_rancher.tftest.hcl
@@ -31,6 +31,10 @@ variables {
 run "install_helm_release" {
   command = plan
 
+  variables {
+    bootstrap_password = "superBootstrap1234"
+  }
+
   assert {
     condition     = output.release_name == "rancher"
     error_message = "Wrong release name"
@@ -39,6 +43,14 @@ run "install_helm_release" {
   assert {
     condition     = output.server_url == "https://rancher.fabn.dev"
     error_message = "It outputs server url for ${var.hostname}"
+  }
+
+  assert {
+    condition = alltrue([
+      output.bootstrap_password == var.bootstrap_password,
+      output.admin_password == var.admin_password,
+    ])
+    error_message = "It manages passwords"
   }
 }
 
@@ -77,7 +89,7 @@ run "boostrap" {
   }
 
   variables {
-    bootstrap_password = "superBootstrap1234"
+    bootstrap_password = run.install_full_release.bootstrap_password
     admin_password     = "superSecret1234"
   }
 

--- a/k8s/rancher/kind_rancher.tftest.hcl
+++ b/k8s/rancher/kind_rancher.tftest.hcl
@@ -47,8 +47,7 @@ run "install_helm_release" {
 
   assert {
     condition = alltrue([
-      output.bootstrap_password == var.bootstrap_password,
-      output.admin_password == var.admin_password,
+      output.bootstrap_password == var.bootstrap_password
     ])
     error_message = "It manages passwords"
   }

--- a/k8s/rancher/main.tf
+++ b/k8s/rancher/main.tf
@@ -4,7 +4,8 @@ terraform {
       source = "hashicorp/kubernetes"
     }
     helm = {
-      source = "hashicorp/helm"
+      source  = "hashicorp/helm"
+      version = ">= 3.0"
     }
     random = {
       source = "hashicorp/random"

--- a/k8s/rancher/outputs.tf
+++ b/k8s/rancher/outputs.tf
@@ -41,9 +41,13 @@ output "rancher_token" {
   sensitive = true
 }
 
+locals {
+  yaml_values = length(helm_release.rancher.values) > 0 ? yamldecode(join("\n", helm_release.rancher.values)) : "{}"
+}
+
 output "values" {
   description = "Rendered values through values attributes as object"
-  value       = length(helm_release.rancher.values) > 0 ? yamldecode(join("\n", helm_release.rancher.values)) : {}
+  value       = yamldecode(local.yaml_values)
   sensitive   = true
 }
 

--- a/k8s/rancher/outputs.tf
+++ b/k8s/rancher/outputs.tf
@@ -52,3 +52,8 @@ output "set" {
   value       = { for s in nonsensitive(helm_release.rancher.set) : s.name => s.value if s.name != "globalConfig.signing_key" }
   sensitive   = true
 }
+
+output "hostname" {
+  description = "The hostname used to access rancher"
+  value       = var.hostname
+}

--- a/k8s/rancher/outputs.tf
+++ b/k8s/rancher/outputs.tf
@@ -42,7 +42,7 @@ output "rancher_token" {
 }
 
 locals {
-  yaml_values = length(helm_release.rancher.values) > 0 ? yamldecode(join("\n", helm_release.rancher.values)) : "{}"
+  yaml_values = length(helm_release.rancher.values) > 0 ? join("\n", helm_release.rancher.values) : "{}"
 }
 
 output "values" {

--- a/k8s/rancher/outputs.tf
+++ b/k8s/rancher/outputs.tf
@@ -14,31 +14,9 @@ output "chart_version" {
   value       = helm_release.rancher.metadata.version
 }
 
-output "bootstrap_password" {
-  description = "The bootstrap password"
-  value       = local.bootstrap_password
-  sensitive   = true
-}
-
-output "admin_password" {
-  description = "The current password for the admin user"
-  value       = local.admin_password
-  sensitive   = true
-}
-
 output "server_url" {
   description = "The server url for rancher"
   value       = local.server_url
-}
-
-output "rancher_token" {
-  description = "The tokens to access the rancher API"
-  value = {
-    api_token  = rancher2_bootstrap.admin.token,
-    access_key = rancher2_bootstrap.admin.token_id
-    secret_key = split(":", rancher2_bootstrap.admin.token)[1]
-  }
-  sensitive = true
 }
 
 locals {

--- a/k8s/rancher/outputs.tf
+++ b/k8s/rancher/outputs.tf
@@ -11,7 +11,7 @@ output "namespace" {
 
 output "chart_version" {
   description = "Installed chart version"
-  value       = one(helm_release.rancher.metadata).version
+  value       = helm_release.rancher.metadata.version
 }
 
 output "bootstrap_password" {

--- a/k8s/rancher/outputs.tf
+++ b/k8s/rancher/outputs.tf
@@ -43,7 +43,7 @@ output "rancher_token" {
 
 output "values" {
   description = "Rendered values through values attributes as object"
-  value       = yamldecode(join("\n", helm_release.rancher.values))
+  value       = length(helm_release.rancher.values) > 0 ? yamldecode(join("\n", helm_release.rancher.values)) : {}
   sensitive   = true
 }
 

--- a/k8s/rancher/outputs.tf
+++ b/k8s/rancher/outputs.tf
@@ -14,6 +14,12 @@ output "chart_version" {
   value       = helm_release.rancher.metadata.version
 }
 
+output "bootstrap_password" {
+  description = "The bootstrap password"
+  value       = local.bootstrap_password
+  sensitive   = true
+}
+
 output "server_url" {
   description = "The server url for rancher"
   value       = local.server_url

--- a/k8s/rancher/rancher.tf
+++ b/k8s/rancher/rancher.tf
@@ -101,4 +101,6 @@ resource "rancher2_bootstrap" "admin" {
   password = local.admin_password
   # By default generate a token that doesn't expire
   token_ttl = 0
+  # Make dependency explicit
+  depends_on = [helm_release.rancher]
 }

--- a/k8s/rancher/rancher.tf
+++ b/k8s/rancher/rancher.tf
@@ -1,7 +1,9 @@
 # bootstrap and admin password
 resource "random_password" "bootstrap" {
   count  = var.bootstrap_password == null ? 1 : 0
-  length = 16
+  length = 20
+  # Some chars might break values output when parsed as yaml
+  special = false
 }
 
 locals {

--- a/k8s/rancher/rancher.tf
+++ b/k8s/rancher/rancher.tf
@@ -54,6 +54,20 @@ locals {
       environment = coalesce(var.letsencrypt.environment, "production")
     }
   }
+
+  base_values = {
+    hostname          = var.hostname
+    bootstrapPassword = local.bootstrap_password
+    # Can be ingress or external, default is ingress but it requires cert
+    # manager to be installed, since it declare an Issuer
+    tls      = !var.letsencrypt.enabled && var.self_signed ? "external" : "ingress"
+    replicas = var.replicas
+  }
+
+  final_values = merge(
+    local.base_values,
+    var.ingress_class_name != null ? { "ingress.ingressClassName" = var.ingress_class_name } : {}
+  )
 }
 
 resource "helm_release" "rancher" {
@@ -67,6 +81,7 @@ resource "helm_release" "rancher" {
   disable_webhooks  = var.disable_hooks # Some hook fails in CI so disable them
   disable_crd_hooks = var.disable_hooks # Some hook fails in CI so disable them
 
+  set = [for k, v in local.final_values : { name = k, value = tostring(v) }]
 
   # List of YAML templates to merge
   values = compact([
@@ -76,37 +91,6 @@ resource "helm_release" "rancher" {
     # Additional extra values to pass to the chart
     var.extra_values != null ? yamlencode(var.extra_values) : null,
   ])
-
-  set {
-    name  = "hostname"
-    value = var.hostname
-  }
-
-  set {
-    name  = "bootstrapPassword"
-    value = local.bootstrap_password
-  }
-
-  # Can be ingress or external, default is ingress but it requires cert
-  # manager to be installed, since it declare an Issuer
-  set {
-    name  = "tls"
-    value = !var.letsencrypt.enabled && var.self_signed ? "external" : "ingress"
-  }
-
-  set {
-    name  = "replicas"
-    value = var.replicas
-  }
-
-  # Optionally sets a specific ingress class name
-  dynamic "set" {
-    for_each = var.ingress_class_name != null ? [1] : []
-    content {
-      name  = "ingress.ingressClassName"
-      value = var.ingress_class_name
-    }
-  }
 }
 
 # Bootstrap the rancher installation
@@ -115,8 +99,6 @@ resource "rancher2_bootstrap" "admin" {
   initial_password = local.bootstrap_password
   # Will be kept in sync for the admin user
   password = local.admin_password
-  # Don't send telemetry data
-  telemetry = false
   # By default generate a token that doesn't expire
   token_ttl = 0
 }

--- a/k8s/rancher/rancher.tf
+++ b/k8s/rancher/rancher.tf
@@ -1,5 +1,11 @@
+# bootstrap and admin password
+resource "random_password" "bootstrap" {
+  count  = var.bootstrap_password == null ? 1 : 0
+  length = 16
+}
 
 locals {
+  bootstrap_password = var.bootstrap_password != null ? var.bootstrap_password : random_password.bootstrap[0].result
   # Final server url, always in https
   server_url = "https://${var.hostname}"
 
@@ -44,7 +50,8 @@ locals {
   }
 
   base_values = {
-    hostname = var.hostname
+    hostname          = var.hostname
+    bootstrapPassword = local.bootstrap_password
     # Can be ingress or external, default is ingress but it requires cert
     # manager to be installed, since it declare an Issuer
     tls      = !var.letsencrypt.enabled && var.self_signed ? "external" : "ingress"

--- a/k8s/rancher/rancher.tf
+++ b/k8s/rancher/rancher.tf
@@ -1,17 +1,5 @@
-# bootstrap and admin password
-resource "random_password" "bootstrap" {
-  count  = var.bootstrap_password == null ? 1 : 0
-  length = 16
-}
-
-resource "random_password" "admin" {
-  count  = var.admin_password == null ? 1 : 0
-  length = 16
-}
 
 locals {
-  bootstrap_password = var.bootstrap_password != null ? var.bootstrap_password : random_password.bootstrap[0].result
-  admin_password     = var.admin_password != null ? var.admin_password : random_password.admin[0].result
   # Final server url, always in https
   server_url = "https://${var.hostname}"
 
@@ -56,8 +44,7 @@ locals {
   }
 
   base_values = {
-    hostname          = var.hostname
-    bootstrapPassword = local.bootstrap_password
+    hostname = var.hostname
     # Can be ingress or external, default is ingress but it requires cert
     # manager to be installed, since it declare an Issuer
     tls      = !var.letsencrypt.enabled && var.self_signed ? "external" : "ingress"
@@ -91,16 +78,4 @@ resource "helm_release" "rancher" {
     # Additional extra values to pass to the chart
     var.extra_values != null ? yamlencode(var.extra_values) : null,
   ])
-}
-
-# Bootstrap the rancher installation
-resource "rancher2_bootstrap" "admin" {
-  # Used to bootstrap the rancher installation
-  initial_password = local.bootstrap_password
-  # Will be kept in sync for the admin user
-  password = local.admin_password
-  # By default generate a token that doesn't expire
-  token_ttl = 0
-  # Make dependency explicit
-  depends_on = [helm_release.rancher]
 }

--- a/k8s/rancher/rancher.tf
+++ b/k8s/rancher/rancher.tf
@@ -85,7 +85,7 @@ resource "helm_release" "rancher" {
 
   # List of YAML templates to merge
   values = compact([
-    local.performance_dashboard,
+    var.enable_performance_dashboard ? local.performance_dashboard : null,
     # Let's encrypt settings
     var.letsencrypt.enabled ? yamlencode(local.tls_values) : null,
     # Additional extra values to pass to the chart

--- a/k8s/rancher/rancher.tf
+++ b/k8s/rancher/rancher.tf
@@ -16,14 +16,14 @@ locals {
   server_url = "https://${var.hostname}"
 
   # # https://ranchermanager.docs.rancher.com/how-to-guides/advanced-user-guides/monitoring-alerting-guides/enable-monitoring#enabling-the-rancher-performance-dashboard
-  performance_dashboard = yamlencode({
+  performance_dashboard = {
     extraEnv = [
       {
         name  = "CATTLE_PROMETHEUS_METRICS"
         value = "true"
       }
     ]
-  })
+  }
 
 }
 resource "kubernetes_namespace_v1" "ns" {
@@ -85,7 +85,7 @@ resource "helm_release" "rancher" {
 
   # List of YAML templates to merge
   values = compact([
-    var.enable_performance_dashboard ? local.performance_dashboard : null,
+    var.enable_performance_dashboard ? yamlencode(local.performance_dashboard) : null,
     # Let's encrypt settings
     var.letsencrypt.enabled ? yamlencode(local.tls_values) : null,
     # Additional extra values to pass to the chart

--- a/k8s/rancher/values.tftest.hcl
+++ b/k8s/rancher/values.tftest.hcl
@@ -1,0 +1,30 @@
+provider "kubernetes" {
+  config_path    = "~/.kube/config"
+  config_context = "kind-kind"
+}
+
+provider "helm" {
+  kubernetes = {
+    config_path    = "~/.kube/config"
+    config_context = "kind-kind"
+  }
+}
+
+variables {
+  hostname = "rancher.fabn.dev"
+  replicas = 1
+}
+
+run "values_output" {
+  command = plan
+
+  assert {
+    condition     = keys(output.values) == []
+    error_message = "Values output is not empty"
+  }
+
+  assert {
+    condition     = output.values == {}
+    error_message = "Values output is not empty"
+  }
+}

--- a/k8s/rancher/variables.tf
+++ b/k8s/rancher/variables.tf
@@ -46,6 +46,13 @@ variable "resources" {
   }
 }
 
+variable "bootstrap_password" {
+  description = "The password to use for bootstrapping rancher, pass this only to import existing installations"
+  type        = string
+  default     = null
+  nullable    = true
+}
+
 variable "hostname" {
   description = "The hostname to configure for rancher"
   type        = string

--- a/k8s/rancher/variables.tf
+++ b/k8s/rancher/variables.tf
@@ -106,7 +106,9 @@ variable "letsencrypt" {
     environment = optional(string, "production")
   })
   default = {
-    email = "" # Will fail if not set
+    enabled     = false
+    email       = "" # Will fail if not set
+    environment = "production"
   }
   validation {
     condition     = !var.letsencrypt.enabled || length(var.letsencrypt.email) > 0

--- a/k8s/rancher/variables.tf
+++ b/k8s/rancher/variables.tf
@@ -81,7 +81,7 @@ variable "ingress_class_name" {
 
 variable "extra_values" {
   description = "Extra values to pass to the helm chart"
-  type        = map(any)
+  type        = any # Should be map(any) but causes issues with TF about all elements being known
   nullable    = true
   default     = null
 }

--- a/k8s/rancher/variables.tf
+++ b/k8s/rancher/variables.tf
@@ -46,20 +46,6 @@ variable "resources" {
   }
 }
 
-variable "bootstrap_password" {
-  description = "The password to use for bootstrapping rancher, pass this only to import existing installations"
-  type        = string
-  default     = null
-  nullable    = true
-}
-
-variable "admin_password" {
-  description = "The password to use for the admin user"
-  type        = string
-  default     = null
-  nullable    = true
-}
-
 variable "hostname" {
   description = "The hostname to configure for rancher"
   type        = string

--- a/k8s/rancher/variables.tf
+++ b/k8s/rancher/variables.tf
@@ -101,14 +101,12 @@ variable "disable_hooks" {
 variable "letsencrypt" {
   description = "Settings for letsencrypt"
   type = object({
-    enabled     = optional(bool)
+    enabled     = optional(bool, false)
     email       = string
-    environment = optional(string)
+    environment = optional(string, "production")
   })
   default = {
-    enabled     = false
-    email       = "" # Will fail if not set
-    environment = "production"
+    email = "" # Will fail if not set
   }
   validation {
     condition     = !var.letsencrypt.enabled || length(var.letsencrypt.email) > 0

--- a/k8s/rancher/variables.tf
+++ b/k8s/rancher/variables.tf
@@ -113,3 +113,9 @@ variable "letsencrypt" {
     error_message = "Email must be set when letsencrypt is enabled"
   }
 }
+
+variable "enable_performance_dashboard" {
+  description = "Whether to enable the performance dashboard (needs rancher monitoring to be enabled)"
+  type        = bool
+  default     = false
+}

--- a/misc/finalizer/main.tf
+++ b/misc/finalizer/main.tf
@@ -20,6 +20,8 @@ variable "name" {
 variable "namespace" {
   description = "The namespace to pass to kubectl"
   type        = string
+  nullable    = true
+  default     = null
 }
 
 variable "sleep_for" {
@@ -28,14 +30,14 @@ variable "sleep_for" {
 }
 
 resource "time_sleep" "wait" {
-  destroy_duration = "30s"
+  destroy_duration = var.sleep_for
 }
 
 resource "null_resource" "remove_finalizers" {
   depends_on = [time_sleep.wait]
   provisioner "local-exec" {
     command = <<EOT
-      kubectl patch ${var.type}/${var.name} -n ${var.namespace} --type json --patch='[ { "op": "remove", "path": "/metadata/finalizers" } ]'
+      kubectl patch ${var.type}/${var.name} ${var.namespace != null ? "-n ${var.namespace}" : ""} --type json --patch='[ { "op": "remove", "path": "/metadata/finalizers" } ]'
     EOT
   }
 }


### PR DESCRIPTION
This pull request refactors and simplifies the Rancher Helm chart deployment configuration, modernizes provider configuration syntax, and updates module dependencies. The most significant changes are the consolidation of `set` blocks for Helm values, improved handling of ingress class names, and a version constraint added for the Helm provider.

**Helm chart configuration refactor:**

* Consolidated multiple explicit `set` blocks into a single `set` list generated from merged local values (`local.final_values`), making the Helm release configuration more maintainable and less error-prone. This also includes conditional handling of the ingress class name. (`k8s/rancher/rancher.tf`, [[1]](diffhunk://#diff-80cc39f796ae0762e8f3a2b573d8edf05b245334ee2601e9a6206800bde02d7bR57-R70) [[2]](diffhunk://#diff-80cc39f796ae0762e8f3a2b573d8edf05b245334ee2601e9a6206800bde02d7bR84) [[3]](diffhunk://#diff-80cc39f796ae0762e8f3a2b573d8edf05b245334ee2601e9a6206800bde02d7bL79-L109)
* Removed the explicit `telemetry = false` from the `rancher2_bootstrap` resource, relying on default behavior or external configuration. (`k8s/rancher/rancher.tf`, [k8s/rancher/rancher.tfL118-L119](diffhunk://#diff-80cc39f796ae0762e8f3a2b573d8edf05b245334ee2601e9a6206800bde02d7bL118-L119))

**Provider and dependency updates:**

* Updated the Helm provider configuration syntax to use an inline map for `kubernetes`, aligning with current Terraform best practices. (`k8s/rancher/configuration.tftest.hcl`, [[1]](diffhunk://#diff-2364e30af5b3be14ead699a1b8eb6b752ea5971905044309c3053deafe501f54L7-R7); `k8s/rancher/kind_rancher.tftest.hcl`, [[2]](diffhunk://#diff-b1566101e07dd9a7b7972dc36ea481c843b1ad93acca6aeee5c9ca873c26c140L7-R7)
* Added a version constraint (`>= 3.0`) to the Helm provider source, ensuring compatibility and reproducibility. (`k8s/rancher/main.tf`, [k8s/rancher/main.tfR8](diffhunk://#diff-31eb80f1a1ee81fecc7b8947365c250a941ac060917f672037b1148f23a3ddf7R8))

**Output fixes:**

* Fixed the `chart_version` output to reference the correct attribute directly, improving reliability. (`k8s/rancher/outputs.tf`, [k8s/rancher/outputs.tfL14-R14](diffhunk://#diff-864197e0b96d7cd02ea1d3cf96933ccc9a68e89342c8714493262855c2f28474L14-R14))