### PR TITLE
Allow cattle-system namespace customization

### DIFF
--- a/k8s/rancher/rancher.tf
+++ b/k8s/rancher/rancher.tf
@@ -20,12 +20,14 @@ locals {
       }
     ]
   }
-
 }
+
 resource "kubernetes_namespace_v1" "ns" {
   count = var.create_namespace ? 1 : 0
   metadata {
-    name = var.namespace
+    name        = var.namespace
+    labels      = var.namespace_labels
+    annotations = var.namespace_annotations
   }
   # Used mainly in test to allow the namespace to be destroyed
   provisioner "local-exec" {

--- a/k8s/rancher/variables.tf
+++ b/k8s/rancher/variables.tf
@@ -114,3 +114,15 @@ variable "enable_performance_dashboard" {
   type        = bool
   default     = false
 }
+
+variable "namespace_labels" {
+  description = "Labels to add to the namespace"
+  type        = map(string)
+  default     = {}
+}
+
+variable "namespace_annotations" {
+  description = "Annotations to add to the namespace"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
This pull request introduces support for adding custom labels and annotations to Kubernetes namespaces managed by this Terraform module. The main changes include new input variables and updates to the namespace resource configuration.

**Namespace customization:**

* Added `namespace_labels` and `namespace_annotations` input variables to allow users to specify labels and annotations for the namespace.
* Updated the `kubernetes_namespace_v1` resource in `rancher.tf` to apply the provided labels and annotations when creating the namespace.