### PR TITLE
Add support for before init hook in contexts

### DIFF
--- a/spacelift/context/main.tf
+++ b/spacelift/context/main.tf
@@ -15,6 +15,7 @@ resource "spacelift_context" "context" {
   description = var.description
   labels      = [for label in var.attach_to : "autoattach:${label}"]
   space_id    = data.spacelift_space.root.id
+  before_init = var.before_init
 }
 
 resource "spacelift_environment_variable" "env" {

--- a/spacelift/context/variables.tf
+++ b/spacelift/context/variables.tf
@@ -34,3 +34,9 @@ variable "terraform_variables" {
   default     = {}
   sensitive   = true
 }
+
+variable "before_init" {
+  description = "List of before init scripts to perform upon context initialization"
+  default     = []
+  type        = list(string)
+}


### PR DESCRIPTION
When creating context it could be useful to pass additional hooks, e.g. for git authentication:

```tf
module "github_context" {
  source      = "github.com/fabn/terraform-modules//spacelift/context"
  name        = "Github context, used to interact with github itself"
  description = "This context will provide credentials to interact with github service"
  attach_to   = ["github"]
  environment_variables = {
    GITHUB_TOKEN = data.sops_file.credentials.data["GITHUB_TOKEN"]
  }
  before_init = [
    "git config --global credential.helper store",
    "echo \"https://$GITHUB_TOKEN:@github.com\" > ~/.git-credentials"
  ]
}

```