### PR TITLE
Regenerate rancher token used in bootstrap

### DIFF
--- a/k8s/rancher/bootstrap/rancher-bootstrap.tf
+++ b/k8s/rancher/bootstrap/rancher-bootstrap.tf
@@ -25,4 +25,6 @@ resource "rancher2_bootstrap" "admin" {
   password = local.admin_password
   # By default generate a token that doesn't expire
   token_ttl = 0
+  # Refresh the token on each apply when expired
+  token_update = var.token_update
 }

--- a/k8s/rancher/bootstrap/variables.tf
+++ b/k8s/rancher/bootstrap/variables.tf
@@ -11,3 +11,9 @@ variable "admin_password" {
   nullable    = true
   sensitive   = true
 }
+
+variable "token_update" {
+  description = "Whether to update the token on each apply when expired"
+  type        = bool
+  default     = true
+}

--- a/k8s/rancher/main.tf
+++ b/k8s/rancher/main.tf
@@ -11,7 +11,8 @@ terraform {
       source = "hashicorp/random"
     }
     rancher2 = {
-      source = "rancher/rancher2"
+      source  = "rancher/rancher2"
+      version = ">= 8"
     }
   }
 }


### PR DESCRIPTION
This pull request introduces improvements to the Rancher Terraform configuration, primarily by adding support for automatic token refresh and updating the Rancher provider version requirement. The main changes are grouped below.

**Token management improvements:**

* Added a new variable `token_update` to control whether the admin token should be refreshed on each apply when expired, with a default value of `true`. (`k8s/rancher/bootstrap/variables.tf`)
* Updated the `rancher2_bootstrap` resource to use the new `token_update` variable, enabling token refresh behavior. (`k8s/rancher/bootstrap/rancher-bootstrap.tf`)

**Provider version update:**

* Set the required `rancher2` provider version to `>= 8` to ensure compatibility with newer features. (`k8s/rancher/main.tf`)