### PR TITLE
Add github_enterprise namespace support to spacelift stack

### DIFF
--- a/spacelift/stack/main.tf
+++ b/spacelift/stack/main.tf
@@ -27,6 +27,13 @@ resource "spacelift_stack" "stack" {
   terraform_version               = "1.5.7"
   terraform_workflow_tool         = "TERRAFORM_FOSS"
   runner_image                    = var.runner_image
+
+  dynamic "github_enterprise" {
+    for_each = var.namespace != null ? [var.namespace] : []
+    content {
+      namespace = github_enterprise.value
+    }
+  }
 }
 
 resource "spacelift_environment_variable" "secrets" {

--- a/spacelift/stack/variables.tf
+++ b/spacelift/stack/variables.tf
@@ -69,6 +69,12 @@ variable "terraform_variables" {
   sensitive = true
 }
 
+variable "namespace" {
+  description = "GitHub org/user owner of the repository. When set, a github_enterprise block is used instead of the default integration."
+  type        = string
+  default     = null
+}
+
 variable "dependencies" {
   description = "Map of dependencies from other stacks"
   type        = map(map(string))


### PR DESCRIPTION
## Summary

- Adds a `namespace` variable (`string`, default `null`) to allow pointing a stack at a repository owned by a different GitHub org/user than the default integration
- Adds a `dynamic "github_enterprise"` block to `spacelift_stack` that activates only when `namespace` is set

This enables creating stacks for repositories outside the default GitHub namespace (e.g. personal repos like `fabn/claw` instead of `fabn-business/terraform`).

## Usage

```hcl
module "my_stack" {
  source     = "./spacelift/stack"
  name       = "claw"
  repository = "claw"
  namespace  = "fabn"
  # ...
}
```

When `namespace` is omitted, behavior is unchanged — the default GitHub integration is used.

## Test plan

- [ ] Apply a stack **without** `namespace` set and verify no `github_enterprise` block is generated
- [ ] Apply a stack **with** `namespace` set and verify the stack correctly points to the specified GitHub org/user