### PR TITLE
Replace deprecated administrative flag with Space Admin role attachment

### DIFF
--- a/spacelift/stack/main.tf
+++ b/spacelift/stack/main.tf
@@ -2,6 +2,8 @@ terraform {
   required_providers {
     spacelift = {
       source = "spacelift-io/spacelift"
+      # 1.37.0 is the first release where spacelift_role_attachment supports stacks
+      version = ">= 1.37.0"
     }
   }
 }
@@ -16,7 +18,6 @@ resource "spacelift_stack" "stack" {
   space_id                        = data.spacelift_space.root.id
   repository                      = var.repository
   branch                          = var.branch
-  administrative                  = var.administrative
   labels                          = var.labels
   project_root                    = var.project_root
   autodeploy                      = var.autodeploy
@@ -34,6 +35,20 @@ resource "spacelift_stack" "stack" {
       namespace = github_enterprise.value
     }
   }
+}
+
+# Replaces the deprecated `administrative` stack attribute: grants the stack
+# the built-in Space Admin role on its own space via a role attachment.
+data "spacelift_role" "space_admin" {
+  count = var.administrative ? 1 : 0
+  slug  = "space-admin"
+}
+
+resource "spacelift_role_attachment" "administrative" {
+  count    = var.administrative ? 1 : 0
+  stack_id = spacelift_stack.stack.id
+  role_id  = data.spacelift_role.space_admin[0].id
+  space_id = data.spacelift_space.root.id
 }
 
 resource "spacelift_environment_variable" "secrets" {

--- a/spacelift/stack/stack.tftest.hcl
+++ b/spacelift/stack/stack.tftest.hcl
@@ -20,6 +20,46 @@ run "simple" {
     condition     = output.stack_id == spacelift_stack.stack.id
     error_message = "Stack ID was not set as output"
   }
+
+  assert {
+    condition     = length(spacelift_role_attachment.administrative) == 0
+    error_message = "No role attachment should be created for non-administrative stacks"
+  }
+}
+
+run "administrative" {
+  override_data {
+    target = data.spacelift_role.space_admin[0]
+    values = {
+      id = "space-admin-role-id"
+    }
+  }
+
+  override_data {
+    target = data.spacelift_space.root
+    values = {
+      id = "root"
+    }
+  }
+
+  variables {
+    administrative = true
+  }
+
+  assert {
+    condition     = spacelift_role_attachment.administrative[0].role_id == "space-admin-role-id"
+    error_message = "Space Admin role was not attached"
+  }
+
+  assert {
+    condition     = spacelift_role_attachment.administrative[0].stack_id == spacelift_stack.stack.id
+    error_message = "Role attachment does not target the stack"
+  }
+
+  assert {
+    condition     = spacelift_role_attachment.administrative[0].space_id == "root"
+    error_message = "Role attachment does not target the stack's space"
+  }
 }
 
 run "create_context" {

--- a/spacelift/stack/variables.tf
+++ b/spacelift/stack/variables.tf
@@ -33,7 +33,7 @@ variable "project_root" {
 }
 
 variable "administrative" {
-  description = "Whether the stack should have administrative privileges."
+  description = "Whether the stack should have administrative privileges, granted by attaching the Space Admin role on the stack's own space."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
The spacelift_stack administrative attribute is deprecated and has been
ineffective since June 1st 2026, when Spacelift auto-migrated it to a
Space Admin role attachment on each stack's own space.

Keep the module's administrative variable as the switch, but implement it
via spacelift_role_attachment binding the built-in space-admin system role
to the stack in its own space. Pin the provider to >= 1.37.0, the first
release where role attachments support stacks.

Consumers that had administrative = true and got the automatic June 1st
migration may need to import the existing attachment:
terraform import ... STACK/$ROLE_ATTACHMENT_ID

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AAyPTK9yyyRVXBMqGq2gBn