### PR TITLE
Add an aws/vpc_data module for deploying into a network you did not create

### DIFF
--- a/aws/vpc_data/main.tf
+++ b/aws/vpc_data/main.tf
@@ -1,0 +1,61 @@
+# Look up an existing VPC and its subnets by tag, so a root that deploys *into*
+# someone else's network does not have to be wired to the state that created it.
+#
+# The alternative is a remote state data source or a set of hardcoded ids. Both
+# couple two configurations that otherwise share nothing: the first makes every
+# consumer a reader of the producer's state, the second turns a network rebuild
+# into an edit in every consumer. Tags are the contract AWS already provides.
+#
+# Read-only by construction — this module creates nothing.
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+data "aws_vpc" "this" {
+  filter {
+    name   = "tag:Name"
+    values = [var.vpc_name]
+  }
+}
+
+# One lookup per subnet group, and only for the groups a caller asks for. A root
+# that places a database in private subnets has no use for the public ones, and
+# an unused data source is still a call that can fail — on permissions, or on a
+# tag convention that happens not to exist in that account.
+data "aws_subnets" "private" {
+  count = var.private_subnet_tags == null ? 0 : 1
+
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.this.id]
+  }
+
+  dynamic "filter" {
+    for_each = var.private_subnet_tags
+    content {
+      name   = "tag:${filter.key}"
+      values = [filter.value]
+    }
+  }
+}
+
+data "aws_subnets" "public" {
+  count = var.public_subnet_tags == null ? 0 : 1
+
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.this.id]
+  }
+
+  dynamic "filter" {
+    for_each = var.public_subnet_tags
+    content {
+      name   = "tag:${filter.key}"
+      values = [filter.value]
+    }
+  }
+}

--- a/aws/vpc_data/outputs.tf
+++ b/aws/vpc_data/outputs.tf
@@ -1,0 +1,27 @@
+output "id" {
+  description = "ID of the VPC."
+  value       = data.aws_vpc.this.id
+}
+
+output "arn" {
+  description = "ARN of the VPC."
+  value       = data.aws_vpc.this.arn
+}
+
+output "cidr_block" {
+  description = "Primary IPv4 CIDR block of the VPC — what a security group rule opens itself to when the caller wants VPC-wide access."
+  value       = data.aws_vpc.this.cidr_block
+}
+
+# An empty list, not null, when the group was not requested. A caller passing
+# these straight into a subnet group or a load balancer gets a legible "no
+# subnets" failure rather than a type error several resources later.
+output "private_subnet_ids" {
+  description = "IDs of the subnets matching private_subnet_tags; empty when that lookup was skipped."
+  value       = var.private_subnet_tags == null ? [] : one(data.aws_subnets.private[*].ids)
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the subnets matching public_subnet_tags; empty when that lookup was skipped."
+  value       = var.public_subnet_tags == null ? [] : one(data.aws_subnets.public[*].ids)
+}

--- a/aws/vpc_data/variables.tf
+++ b/aws/vpc_data/variables.tf
@@ -1,0 +1,24 @@
+variable "vpc_name" {
+  description = "Value of the VPC's Name tag."
+  type        = string
+}
+
+# No default on purpose. Which tags mark a subnet private is a convention of
+# whoever built the network, not something a shared module can guess: some
+# estates tag `kind = private`, a cluster built for the AWS Load Balancer
+# Controller tags `kubernetes.io/role/internal-elb = 1`, and picking one of
+# those as a default would silently return the wrong subnets in the other.
+#
+# Null means "do not look these up at all" rather than "look up everything",
+# so asking for one group never makes the module read the other.
+variable "private_subnet_tags" {
+  description = "Tags identifying the private subnets, as key/value pairs all of which must match. Null skips the lookup."
+  type        = map(string)
+  default     = null
+}
+
+variable "public_subnet_tags" {
+  description = "Tags identifying the public subnets, as key/value pairs all of which must match. Null skips the lookup."
+  type        = map(string)
+  default     = null
+}

--- a/aws/vpc_data/vpc_data.tftest.hcl
+++ b/aws/vpc_data/vpc_data.tftest.hcl
@@ -1,0 +1,104 @@
+# The module reads AWS and creates nothing, so the provider is mocked: what is
+# worth asserting is the lookup logic, not the values AWS would return.
+#
+# The one behaviour with real logic in it is the conditional lookup — a group
+# whose tags are null must not be read, and must still produce a usable empty
+# list rather than null.
+
+mock_provider "aws" {
+  mock_data "aws_vpc" {
+    defaults = {
+      id         = "vpc-0123456789abcdef0"
+      arn        = "arn:aws:ec2:eu-south-1:123456789012:vpc/vpc-0123456789abcdef0"
+      cidr_block = "10.0.0.0/16"
+    }
+  }
+
+  mock_data "aws_subnets" {
+    defaults = {
+      ids = ["subnet-aaa", "subnet-bbb", "subnet-ccc"]
+    }
+  }
+}
+
+run "vpc_attributes_come_from_the_name_lookup" {
+  command = apply
+
+  variables {
+    vpc_name = "example-vpc"
+  }
+
+  assert {
+    condition     = output.id == "vpc-0123456789abcdef0"
+    error_message = "the VPC id should come from the Name tag lookup"
+  }
+
+  assert {
+    condition     = output.cidr_block == "10.0.0.0/16"
+    error_message = "the CIDR block should be published for callers writing VPC-wide rules"
+  }
+}
+
+run "no_subnet_tags_means_no_subnet_lookup" {
+  command = apply
+
+  variables {
+    vpc_name = "example-vpc"
+  }
+
+  assert {
+    condition     = length(data.aws_subnets.private) == 0 && length(data.aws_subnets.public) == 0
+    error_message = "a caller asking for no subnet group should trigger no subnet lookup"
+  }
+
+  # Empty rather than null: a caller passing this into a subnet group gets a
+  # legible "no subnets" failure instead of a type error further down.
+  assert {
+    condition     = output.private_subnet_ids == [] && output.public_subnet_ids == []
+    error_message = "a skipped lookup should still produce an empty list"
+  }
+}
+
+run "each_group_is_looked_up_independently" {
+  command = apply
+
+  variables {
+    vpc_name            = "example-vpc"
+    private_subnet_tags = { "kubernetes.io/role/internal-elb" = "1" }
+  }
+
+  assert {
+    condition     = length(data.aws_subnets.private) == 1
+    error_message = "requesting the private group should trigger its lookup"
+  }
+
+  assert {
+    condition     = length(data.aws_subnets.public) == 0
+    error_message = "requesting the private group should not trigger the public one"
+  }
+
+  assert {
+    condition     = length(output.private_subnet_ids) == 3
+    error_message = "the private subnet ids should be published"
+  }
+
+  assert {
+    condition     = output.public_subnet_ids == []
+    error_message = "the group that was not requested should stay empty"
+  }
+}
+
+run "both_groups_can_be_requested_together" {
+  command = apply
+
+  variables {
+    vpc_name            = "example-vpc"
+    private_subnet_tags = { "kind" = "private" }
+    public_subnet_tags  = { "kind" = "public" }
+  }
+
+  assert {
+    condition     = length(output.private_subnet_ids) == 3 && length(output.public_subnet_ids) == 3
+    error_message = "both groups should be published when both are requested"
+  }
+}


### PR DESCRIPTION
First module under a new `aws/` group. It resolves an existing VPC and its subnets by tag, for roots that deploy into a network some other configuration owns.

## Why a module rather than two data blocks

The alternatives are a remote state data source or hardcoded ids. The first makes every consumer a reader of the producer's state — a coupling between configurations that otherwise share nothing. The second turns a network rebuild into an edit in every consumer. Tags are the contract AWS already provides, and this reads them.

Two data blocks are also perfectly fine when there is one caller. This exists because there is about to be more than one, all resolving the same network from different roots.

## Subnet tags have no default

Which tags mark a subnet private is a convention of whoever built the network. Some estates tag `kind = private`; a cluster built for the AWS Load Balancer Controller tags `kubernetes.io/role/internal-elb = 1`. Defaulting to either would silently return the wrong subnets in the other — the worst failure mode available here, since the plan looks fine and the resource lands in the wrong place.

`null` means the group is **not looked up at all**, rather than looked up unfiltered. So a root that only places private resources never reads the public subnets, and never fails on a tag convention it does not use. A skipped group still outputs `[]` rather than `null`, so passing it straight into a subnet group gives a legible "no subnets" error instead of a type error several resources later.

## Tests

Mocked provider, four runs: the VPC attributes come from the Name lookup, no tags means no subnet lookup at all, each group is looked up independently, and both can be requested together. The conditional lookup is the only real logic in the module and it is what the tests target.
