### PR TITLE
feat(spacelift/stack): expose five more stack attributes as variables

### DIFF
--- a/spacelift/stack/main.tf
+++ b/spacelift/stack/main.tf
@@ -15,17 +15,20 @@ data "spacelift_space" "root" {
 resource "spacelift_stack" "stack" {
   name                            = var.name
   description                     = var.description
+  slug                            = var.slug
   space_id                        = data.spacelift_space.root.id
   repository                      = var.repository
   branch                          = var.branch
   labels                          = var.labels
   project_root                    = var.project_root
+  additional_project_globs        = var.additional_project_globs
   autodeploy                      = var.autodeploy
   terraform_smart_sanitization    = true
   terraform_external_state_access = true
   enable_local_preview            = true
-  protect_from_deletion           = true
-  terraform_version               = "1.5.7"
+  enable_sensitive_outputs_upload = var.enable_sensitive_outputs_upload
+  protect_from_deletion           = var.protect_from_deletion
+  terraform_version               = var.terraform_version
   terraform_workflow_tool         = "TERRAFORM_FOSS"
   runner_image                    = var.runner_image
 

--- a/spacelift/stack/variables.tf
+++ b/spacelift/stack/variables.tf
@@ -9,6 +9,12 @@ variable "description" {
   default     = null
 }
 
+variable "slug" {
+  description = "Slug of the stack. When null the provider derives it from the stack name."
+  type        = string
+  default     = null
+}
+
 variable "space_id" {
   description = "Space where to create the context"
   type        = string
@@ -32,6 +38,12 @@ variable "project_root" {
   type        = string
 }
 
+variable "additional_project_globs" {
+  description = "Paths to track changes of in addition to the project root."
+  type        = set(string)
+  default     = null
+}
+
 variable "administrative" {
   description = "Whether the stack should have administrative privileges, granted by attaching the Space Admin role on the stack's own space."
   type        = bool
@@ -43,6 +55,24 @@ variable "runner_image" {
   type        = string
   default     = null
   # e.g. "fabn/runner-terraform:v1.8.1"
+}
+
+variable "terraform_version" {
+  description = "Terraform version used by the managed stack. Defaults to the last MPL licensed release, which Spacelift default runner images ship."
+  type        = string
+  default     = "1.5.7"
+}
+
+variable "protect_from_deletion" {
+  description = "Whether the stack is protected from deletion. Set to false to retire the stack."
+  type        = bool
+  default     = true
+}
+
+variable "enable_sensitive_outputs_upload" {
+  description = "Whether sensitive outputs are uploaded so dependent stacks can consume them. When null the provider default applies."
+  type        = bool
+  default     = null
 }
 
 variable "labels" {


### PR DESCRIPTION
## Summary

The `spacelift/stack` module wraps `resource "spacelift_stack"` but only exposed 14 variables. Several useful provider attributes were either hardcoded or never set, so consumers could not control them without forking the module. This PR exposes five of them.

Every change is **additive**: each new variable defaults to today's exact behaviour, so existing stacks see no diff.

| Variable | Type | Default | Was |
| --- | --- | --- | --- |
| `additional_project_globs` | `set(string)` | `null` | not set |
| `protect_from_deletion` | `bool` | `true` | hardcoded `true` |
| `terraform_version` | `string` | `"1.5.7"` | hardcoded `"1.5.7"` |
| `slug` | `string` | `null` | not set |
| `enable_sensitive_outputs_upload` | `bool` | `null` | not set |

## Motivation

The driver is **`additional_project_globs`**. Stacks whose `project_root` points at a subdirectory do not start a run when a push only touches shared local modules under `modules/`, so the new module code lands silently on some later, unrelated run of that stack. Tracking extra paths fixes that.

The two hardcoded attributes are exposed because both have already been hit in practice:

- **`protect_from_deletion`** — a hardcoded `true` blocks retiring a stack.
- **`terraform_version`** — stacks running on a custom runner image ship a newer Terraform than the `1.5.7` the stack declares.

The `1.5.7` default is kept deliberately: it is the last MPL-licensed Terraform release and it is what Spacelift's default runner image ships, so consumers that rely on it are unaffected.

`slug` and `enable_sensitive_outputs_upload` are both optional+computed in the provider; leaving them `null` keeps the name-derived slug and the provider default respectively.

## Test plan

- [x] `terraform init -backend=false && terraform validate` in `spacelift/stack/` → `Success! The configuration is valid.`
- [x] `terraform fmt -check -recursive` at repo root → clean
- [x] `terraform -chdir=spacelift/stack test` → `4 passed, 0 failed` (existing mocked suite, unchanged)

No terraform-docs config exists in this repo, so there is no generated documentation to refresh.

## Release note

Suggested labels: `enhancement` + `minor`. Purely additive with behaviour-preserving defaults — no consumer config has to change to upgrade, so this is not a `major` bump. Consumers pin this module by tag (`?ref=v1.2.0`), so cutting the release tag is a separate decision after review.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158uRzd9ytfNNDnqVHNzSob

---
_Generated by [Claude Code](https://claude.ai/code/session_0158uRzd9ytfNNDnqVHNzSob)_